### PR TITLE
Add copy to clipboard button on results

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -16,6 +16,20 @@
             font-family: monospace;
         }
 
+        .copy-btn {
+            margin-bottom: 0.5rem;
+            padding: 0.25rem 0.5rem;
+            font-size: 0.9rem;
+            cursor: pointer;
+        }
+
+        .copy-msg {
+            margin-left: 0.5rem;
+            color: green;
+            font-weight: bold;
+            display: none;
+        }
+
         .container {
             max-width: 800px;
             margin: 2rem auto;
@@ -49,7 +63,9 @@
         {% else %}
             <h2>Response:</h2>
             <div class="result-box">
-                <pre>{{ result }}</pre>
+                <button class="copy-btn" onclick="copyResult()">Copy</button>
+                <span class="copy-msg" id="copy-msg">Copied!</span>
+                <pre id="result-text">{{ result }}</pre>
             </div>
 
             {% if download_link %}
@@ -60,5 +76,18 @@
         <br>
         <a class="button" href="{{ url_for('index') }}">⬅ Back to Home</a>
     </div>
+
+    <script>
+        function copyResult() {
+            const text = document.getElementById('result-text').innerText;
+            navigator.clipboard.writeText(text).then(function () {
+                const msg = document.getElementById('copy-msg');
+                msg.style.display = 'inline';
+                setTimeout(function () {
+                    msg.style.display = 'none';
+                }, 2000);
+            });
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add "Copy" button next to response block
- implement JavaScript function to copy to clipboard and show feedback

## Testing
- `python3 -m py_compile app.py local_pdf_query.py query_any_pdf.py summarise_job_requirements.py utils/cv_feedback.py utils/extract_text.py utils/generate_answers.py utils/interview_questions.py utils/tailor_cv.py`

------
https://chatgpt.com/codex/tasks/task_e_6858ac8204e4832ca199b1350e060ad9