### PR TITLE
Add DOCX export for rewritten CVs

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from utils.cv_feedback import give_cv_feedback, improve_cv
 from utils.tailor_cv import tailor_cv_to_job
 from utils.interview_questions import generate_interview_questions
 from utils.generate_answers import generate_answers_from_cv
+from utils.docx_writer import write_formatted_docx
 
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = 'uploads'
@@ -57,9 +58,8 @@ def process():
                 return render_template("results.html", error="Please upload a CV.")
             cv_text = extract_text_from_file(cv_path)
             rewritten = improve_cv(cv_text)
-            output_file = f"{cv_path}_improved.txt"
-            with open(output_file, 'w') as f:
-                f.write(rewritten)
+            output_file = f"{os.path.splitext(cv_path)[0]}_improved.docx"
+            write_formatted_docx(rewritten, output_file)
             return render_template("results.html", result="Improved CV generated below.", download_link=output_file)
 
         elif task == "tailor_advice":
@@ -75,9 +75,8 @@ def process():
             cv_text = extract_text_from_file(cv_path)
             job_text = extract_text_from_file(job_path)
             tailored = tailor_cv_to_job(cv_text, job_text, mode="rewrite")
-            output_file = f"{cv_path}_tailored.txt"
-            with open(output_file, 'w') as f:
-                f.write(tailored)
+            output_file = f"{os.path.splitext(cv_path)[0]}_tailored.docx"
+            write_formatted_docx(tailored, output_file)
             return render_template("results.html", result="Tailored CV generated below.", download_link=output_file)
 
         elif task == "interview_questions":

--- a/utils/docx_writer.py
+++ b/utils/docx_writer.py
@@ -1,0 +1,25 @@
+from docx import Document
+import re
+
+
+def write_formatted_docx(text: str, output_path: str) -> None:
+    """Create a DOCX file with simple formatting for headings and bullet lists."""
+    doc = Document()
+
+    bullet_regex = re.compile(r"^(?:[-*\u2022]|\d+[.)])\s+")
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            doc.add_paragraph("")
+            continue
+
+        if bullet_regex.match(stripped):
+            content = bullet_regex.sub("", stripped)
+            doc.add_paragraph(content, style="List Bullet")
+        elif stripped.isupper() and len(stripped.split()) <= 6:
+            doc.add_heading(stripped, level=2)
+        else:
+            doc.add_paragraph(stripped)
+
+    doc.save(output_path)


### PR DESCRIPTION
## Summary
- create `utils/docx_writer.py` for basic formatting of CV text into DOCX
- export rewritten and tailored CVs as formatted `.docx` files in `app.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858ac7d5564832c8602811412efb193