### PR TITLE
Show tailored CV text in results

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,11 @@ def process():
             output_file = f"{cv_path}_improved.txt"
             with open(output_file, 'w') as f:
                 f.write(rewritten)
-            return render_template("results.html", result="Improved CV generated below.", download_link=output_file)
+            return render_template(
+                "results.html",
+                result=rewritten,
+                download_link=output_file,
+            )
 
         elif task == "tailor_advice":
             if not cv_path or not job_path:
@@ -78,7 +82,11 @@ def process():
             output_file = f"{cv_path}_tailored.txt"
             with open(output_file, 'w') as f:
                 f.write(tailored)
-            return render_template("results.html", result="Tailored CV generated below.", download_link=output_file)
+            return render_template(
+                "results.html",
+                result=tailored,
+                download_link=output_file,
+            )
 
         elif task == "interview_questions":
             if not job_path:

--- a/templates/results.html
+++ b/templates/results.html
@@ -46,15 +46,17 @@
 
         {% if error %}
             <p class="error">{{ error }}</p>
-        {% else %}
+        {% endif %}
+
+        {% if result %}
             <h2>Response:</h2>
             <div class="result-box">
                 <pre>{{ result }}</pre>
             </div>
+        {% endif %}
 
-            {% if download_link %}
-                <a class="button" href="{{ download_link }}" download>Download Tailored CV</a>
-            {% endif %}
+        {% if download_link %}
+            <a class="button" href="{{ download_link }}" download>Download Tailored CV</a>
         {% endif %}
 
         <br>


### PR DESCRIPTION
## Summary
- return rewritten and tailored CV text to the results template
- always render the result text block on the results page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ac7560d8832cbb3bc897664510ba