### PR TITLE
Secure download endpoint

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -53,7 +53,7 @@
             </div>
 
             {% if download_link %}
-                <a class="button" href="{{ download_link }}" download>Download Tailored CV</a>
+                <a class="button" href="{{ download_link }}">Download File</a>
             {% endif %}
         {% endif %}
 


### PR DESCRIPTION
## Summary
- harden file serving with a dedicated `/download` route
- validate paths to block traversal
- return correct download URLs in results
- adjust download link text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68595bf252fc832cbf38a365efc953da