### PR TITLE
Add env-based debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ source venv/bin/activate
 # Install dependencies
 pip install -r requirements.txt
 
-# Run the app
+# Optional: enable debug output
+export FLASK_DEBUG=True
+
+# Run the app (defaults to non-debug mode)
 python3 app.py
 ```
 

--- a/app.py
+++ b/app.py
@@ -121,4 +121,6 @@ def download_file(filename):
     return send_from_directory(app.config['UPLOAD_FOLDER'], safe_path, as_attachment=True)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_env = os.getenv('FLASK_DEBUG', 'False')
+    debug_mode = debug_env.lower() in ('1', 'true', 'yes', 'y', 't')
+    app.run(debug=debug_mode)


### PR DESCRIPTION
## Summary
- allow configuring debug mode using `FLASK_DEBUG`
- document the optional environment variable in README

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68595cd67204832ca2f8914e2bcdd6fe